### PR TITLE
GML-1591 - Separated Milvus collections for InquiryAI and SupportAI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ wandb/
 report_url.txt
 volumes/*
 configs/SERVICE_ACCOUNT_CREDS.json
+.vscode/*

--- a/app/embeddings/milvus_embedding_store.py
+++ b/app/embeddings/milvus_embedding_store.py
@@ -93,7 +93,7 @@ class MilvusEmbeddingStore(EmbeddingStore):
                 if "seq_num" not in metadata:
                     metadata["seq_num"] = 1
                 if "source" not in metadata:
-                    metadata["source"] = "somesource"
+                    metadata["source"] = ""
 
         logger.info(f"request_id={req_id_cv.get()} Milvus ENTRY add_embeddings()")
         texts = [text for text, _ in embeddings]

--- a/app/main.py
+++ b/app/main.py
@@ -112,12 +112,31 @@ embedding_store = FAISS_EmbeddingStore(embedding_service)
 
 if milvus_config.get("enabled") == "true":
     logger.info(f"Milvus enabled for host {milvus_config['host']} at port {milvus_config['port']}")
+
+    logger.info(f"Setting up Milvus embedding store for InquiryAI")
     embedding_store = MilvusEmbeddingStore(
+            embedding_service,
+            host=milvus_config["host"],
+            port=milvus_config["port"],
+            collection_name="tg_inquiry_documents", 
+            support_ai_instance=False,
+            username=milvus_config.get("username", ""),
+            password=milvus_config.get("password", "")
+    )
+
+    support_collection_name=milvus_config.get("collection_name", "tg_support_documents")
+    logger.info(f"Setting up Milvus embedding store for SupportAI with collection_name: {support_collection_name}")
+    support_ai_embedding_store = MilvusEmbeddingStore(
         embedding_service,
         host=milvus_config["host"],
         port=milvus_config["port"],
+        support_ai_instance=True,
+        collection_name=support_collection_name, 
         username=milvus_config.get("username", ""),
-        password=milvus_config.get("password", "")
+        password=milvus_config.get("password", ""),
+        vector_field=milvus_config.get("vector_field", "document_vector"),
+        text_field=milvus_config.get("text_field", "document_content"),
+        vertex_field=milvus_config.get("vertex_field", "vertex_id")
     )
 
 @app.middleware("http")

--- a/tests/test_milvus_embedding_store.py
+++ b/tests/test_milvus_embedding_store.py
@@ -15,10 +15,10 @@ class TestMilvusEmbeddingStore(unittest.TestCase):
         mock_embedding_model.embed_documents.return_value = embedded_documents
         mock_milvus_function.return_value = None
 
-        embedding_store = MilvusEmbeddingStore(embedding_service=mock_embedding_model, host="localhost", port=19530)
+        embedding_store = MilvusEmbeddingStore(embedding_service=mock_embedding_model, host="localhost", port=19530, support_ai_instance=True)
         embedding_store.add_embeddings(embeddings=[(query, embedded_documents)])
 
-        mock_milvus_function.assert_called_once_with(texts=[query], metadatas=None)
+        mock_milvus_function.assert_called_once_with(texts=[query], metadatas=[])
 
     @patch('langchain_community.vectorstores.milvus.Milvus.similarity_search_by_vector') 
     def test_retrieve_embeddings(self, mock_milvus_function):
@@ -31,7 +31,7 @@ class TestMilvusEmbeddingStore(unittest.TestCase):
         ]
         mock_milvus_function.return_value = docs
 
-        embedding_store = MilvusEmbeddingStore(embedding_service=MagicMock(), host="localhost", port=19530)
+        embedding_store = MilvusEmbeddingStore(embedding_service=MagicMock(), host="localhost", port=19530, support_ai_instance=True)
         result = embedding_store.retrieve_similar(query_embedding=embedded_query, top_k=4)
 
         mock_milvus_function.assert_called_once_with(embedding=embedded_query, k=4)


### PR DESCRIPTION
- Using more Milvus configurations from the file if available
- Separated the embedding store instances for InquiryAI and SupportAI
- Added extra logic to the add_embeddings to make sure that all schema fields are fulfilled
- Only loading documents for InquiryAI