### PR TITLE
GML-1726: handle error when openai API key is not valid

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -27,6 +27,7 @@ from app.tools.logwriter import LogWriter
 security = HTTPBasic()
 session_handler = SessionHandler()
 status_manager = StatusManager()
+service_status = {}
 
 # Configs
 LLM_SERVICE = os.getenv("LLM_CONFIG", "configs/llm_config.json")
@@ -128,35 +129,45 @@ LogWriter.info(
 )
 
 LogWriter.info("Setting up Milvus embedding store for InquiryAI")
-embedding_store = MilvusEmbeddingStore(
-    embedding_service,
-    host=milvus_config["host"],
-    port=milvus_config["port"],
-    collection_name="tg_inquiry_documents",
-    support_ai_instance=False,
-    username=milvus_config.get("username", ""),
-    password=milvus_config.get("password", ""),
-    alias=milvus_config.get("alias", "default"),
-)
+try:
+    embedding_store = MilvusEmbeddingStore(
+        embedding_service,
+        host=milvus_config["host"],
+        port=milvus_config["port"],
+        collection_name="tg_inquiry_documents",
+        support_ai_instance=False,
+        username=milvus_config.get("username", ""),
+        password=milvus_config.get("password", ""),
+        alias=milvus_config.get("alias", "default"),
+    )
+    service_status["embedding_store"] = {"status": "ok", "error": None}
+except Exception as e:
+    embedding_store = None
+    service_status["embedding_store"] = {"status": "error", "error": str(e)}
 
 support_collection_name = milvus_config.get("collection_name", "tg_support_documents")
 LogWriter.info(
     f"Setting up Milvus embedding store for SupportAI with collection_name: {support_collection_name}"
 )
 vertex_field = milvus_config.get("vertex_field", "vertex_id")
-support_ai_embedding_store = MilvusEmbeddingStore(
-    embedding_service,
-    host=milvus_config["host"],
-    port=milvus_config["port"],
-    support_ai_instance=True,
-    collection_name=support_collection_name,
-    username=milvus_config.get("username", ""),
-    password=milvus_config.get("password", ""),
-    vector_field=milvus_config.get("vector_field", "document_vector"),
-    text_field=milvus_config.get("text_field", "document_content"),
-    vertex_field=vertex_field,
-    alias=milvus_config.get("alias", "default"),
-)
+try:
+    support_ai_embedding_store = MilvusEmbeddingStore(
+        embedding_service,
+        host=milvus_config["host"],
+        port=milvus_config["port"],
+        support_ai_instance=True,
+        collection_name=support_collection_name,
+        username=milvus_config.get("username", ""),
+        password=milvus_config.get("password", ""),
+        vector_field=milvus_config.get("vector_field", "document_vector"),
+        text_field=milvus_config.get("text_field", "document_content"),
+        vertex_field=vertex_field,
+        alias=milvus_config.get("alias", "default"),
+    )
+    service_status["support_ai_embedding_store"] = {"status": "ok", "error": None}
+except Exception as e:
+    support_ai_embedding_store = None
+    service_status["support_ai_embedding_store"] = {"status": "error", "error": str(e)}
 
 
 if DOC_PROCESSING_CONFIG is None or (

--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,7 @@ import json
 import os
 
 from fastapi.security import HTTPBasic
+from pymilvus.exceptions import MilvusException
 
 from app.embeddings.embedding_services import (
     AWS_Bedrock_Embedding,
@@ -141,9 +142,12 @@ try:
         alias=milvus_config.get("alias", "default"),
     )
     service_status["embedding_store"] = {"status": "ok", "error": None}
+except MilvusException as e:
+    embedding_store = None
+    service_status["embedding_store"] = {"status": "milvus error", "error": str(e)}
 except Exception as e:
     embedding_store = None
-    service_status["embedding_store"] = {"status": "error", "error": str(e)}
+    service_status["embedding_store"] = {"status": "embedding error", "error": str(e)}
 
 support_collection_name = milvus_config.get("collection_name", "tg_support_documents")
 LogWriter.info(
@@ -165,9 +169,12 @@ try:
         alias=milvus_config.get("alias", "default"),
     )
     service_status["support_ai_embedding_store"] = {"status": "ok", "error": None}
+except MilvusException as e:
+    support_ai_embedding_store = None
+    service_status["support_ai_embedding_store"] = {"status": "milvus error", "error": str(e)}
 except Exception as e:
     support_ai_embedding_store = None
-    service_status["support_ai_embedding_store"] = {"status": "error", "error": str(e)}
+    service_status["support_ai_embedding_store"] = {"status": "embedding error", "error": str(e)}
 
 
 if DOC_PROCESSING_CONFIG is None or (

--- a/app/routers/root.py
+++ b/app/routers/root.py
@@ -18,20 +18,6 @@ def read_root():
 
 @router.get("/health")
 async def health():
-    try:
-        # Check if Milvus is up and running and if the required collections exist
-        connections.connect(host="milvus-standalone", port="19530")
-        # Check if the required collections exist
-        inquiry_collection_exists = utility.has_collection("tg_inquiry_documents")
-        support_collection_exists = utility.has_collection("tg_support_documents")
-
-        if inquiry_collection_exists or support_collection_exists:
-            service_status["milvus"] = {"status": "ok", "error": None}
-        else:
-            service_status["milvus"] = {"status": "error", "error": "Milvus is up and running, but no collection exists"}
-    except Exception as e:
-        service_status["milvus"] = {"status": "error", "error": str(e)}
-    
     status = {
         "status": "unhealthy" if any(v["error"] is not None for v in service_status.values()) else "healthy",
         "details": service_status


### PR DESCRIPTION
Code change:
* Add a global status object to track service status
* The app won't crash if embedding store is not available due to invalid api key
* Currently, the query endpoint will check service status before going further. Ideally, other endpoints could check relavant status as well. 