### PR TITLE
GML-1823: use proxy in vite dev server

### DIFF
--- a/copilot-ui/vite.config.ts
+++ b/copilot-ui/vite.config.ts
@@ -10,4 +10,13 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    proxy: {
+      '/ui': 'http://localhost:8000',
+      '^/ui/.*/chat': {
+        target: 'ws://localhost:8000',
+        ws: true,
+      }
+    }
+  },
 });


### PR DESCRIPTION
Add reverse proxy to the vite dev server so that the frontend can communicate to the backend service at a different port during development. It is only effective for development, i.e., when you run `pnpm run dev` to serve the UI.

